### PR TITLE
Bug fixes and new settings

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -57,14 +57,14 @@ namespace Obfuscar
 		private string filename;
 		private AssemblyDefinition definition;
 		private string name;
-		private bool exclude = false;
+		private bool exclude;
 
-		public bool Exclude {
+        public bool Exclude {
 			get { return exclude; }
 			set { exclude = value; }
 		}
 
-		bool initialized = false;
+		bool initialized;
 		// to create, use FromXml
 		private AssemblyInfo (Project project)
 		{
@@ -441,30 +441,30 @@ namespace Obfuscar
 
 		private IEnumerable<MemberReference> getMemberReferences ()
 		{
-			HashSet<MemberReference> memberreferences = new HashSet<MemberReference> ();
-			foreach (TypeDefinition type in this.GetAllTypeDefinitions()) {
+			HashSet<MemberReference> memberReferences = new HashSet<MemberReference> ();
+			foreach (TypeDefinition type in this.GetAllTypeDefinitions ()) {
 				foreach (MethodDefinition method in type.Methods) {
 
-					foreach (MethodReference memberref in method.Overrides) {
-						if (IsOnlyReference (memberref)) {
-							memberreferences.Add (memberref);
+					foreach (MethodReference memberRef in method.Overrides) {
+						if (IsOnlyReference (memberRef)) {
+							memberReferences.Add (memberRef);
 						}
 					}
 					if (method.Body != null) {
 						foreach (Instruction inst in method.Body.Instructions) {
-							MemberReference memberref = inst.Operand as MemberReference;
-							if (memberref != null) {
-								if (IsOnlyReference (memberref) || memberref is FieldReference && !(memberref is FieldDefinition)) {
+							MemberReference memberRef = inst.Operand as MemberReference;
+							if (memberRef != null) {
+								if (IsOnlyReference (memberRef) || memberRef is FieldReference && !(memberRef is FieldDefinition)) {
 									// FIXME: Figure out why this exists if it is never used.
 									// int c = memberreferences.Count;
-									memberreferences.Add (memberref);
+									memberReferences.Add (memberRef);
 								}
 							}
 						}
 					}
 				}
 			}
-			return memberreferences;
+			return memberReferences;
 		}
 
 		private bool IsOnlyReference (MemberReference memberref)
@@ -486,25 +486,6 @@ namespace Obfuscar
 			}
 
 			return false;
-		}
-
-		IEnumerable<TypeReference> getTypeReferences ()
-		{
-			List<TypeReference> typereferences = new List<TypeReference> ();
-			foreach (TypeDefinition type in this.GetAllTypeDefinitions()) {
-				foreach (MethodDefinition method in type.Methods) {
-					if (method.Body != null) {
-						foreach (Instruction inst in method.Body.Instructions) {
-							TypeReference typeref = inst.Operand as TypeReference;
-							if (typeref != null) {
-								if (!(typeref is TypeDefinition) && !(typeref is TypeSpecification))
-									typereferences.Add (typeref);
-							}
-						}
-					}
-				}
-			}
-			return typereferences;
 		}
 
 		private void LoadAssembly (string filename)

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -58,6 +58,7 @@ namespace Obfuscar
 		private AssemblyDefinition definition;
 		private string name;
 		private bool exclude;
+        private bool skipEnums;
 
         public bool Exclude {
 			get { return exclude; }
@@ -272,6 +273,10 @@ namespace Obfuscar
 								info.forceEvents.Add (new EventTester (name, type, attrib, typeattrib));
 							}
 							break;
+                        case "SkipEnums":
+                            var skipEnumsValue = Helper.GetAttribute (reader, "value");
+                            info.skipEnums = skipEnumsValue.Length > 0 && XmlConvert.ToBoolean (skipEnumsValue);
+                            break;
 						}                    
 					} else if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "Module") {
 						// hit end of module element...stop reading
@@ -649,6 +654,11 @@ namespace Obfuscar
 				return true;
 			}
 
+            if (type.TypeDefinition.IsEnum && skipEnums) {
+                message = "enum rule in configuration";
+                return true;
+            }
+
 			if (type.TypeDefinition.IsTypePublic ()) {
 				message = "KeepPublicApi option in configuration";
 				return keepPublicApi;
@@ -797,6 +807,11 @@ namespace Obfuscar
 				message = "field rule in configuration";
 				return true;
 			}
+
+            if (skipEnums) {
+                message = "enum rule in configuration";
+                return true;
+            }
 
 			if (field.DeclaringType.IsTypePublic () && (field.Field.IsPublic || field.Field.IsFamily)) {
 				message = "KeepPublicApi option in configuration";

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -367,30 +367,42 @@ namespace Obfuscar
 			private void AddParents (List<Node<TypeDefinition>> nodes)
 			{
 				foreach (var node in nodes) {
+                    Node<TypeDefinition> parent;
 					var baseType = node.Item.BaseType;
 					if (baseType != null) {
-						var parent = SearchNode (baseType);
-						node.AppendTo (parent);
+						if (TrySearchNode (baseType, out parent)) {
+						    node.AppendTo (parent);
+                        }
 					}
 
-					if (node.Item.HasInterfaces)
+					if (node.Item.HasInterfaces) {
 						foreach (var inter in node.Item.Interfaces) {
-							var parent = SearchNode (inter);
-							node.AppendTo (parent);
+						    if (TrySearchNode (inter, out parent)) {
+						        node.AppendTo (parent);
+                            }
 						}
+                    }
 
 					var nestedParent = node.Item.DeclaringType;
 					if (nestedParent != null) {
-						var parent = SearchNode (nestedParent);
-						node.AppendTo (parent);                        
+						if (TrySearchNode (nestedParent, out parent)) {
+						    node.AppendTo (parent);
+                        }
 					}
 				}
 			}
 
-			private Node<TypeDefinition> SearchNode (TypeReference baseType)
+			private bool TrySearchNode (TypeReference baseType, out Node<TypeDefinition> parent)
 			{
 				var key = baseType.FullName;
-				return _map.ContainsKey (key) ? _map [key] : null;
+                parent = null;
+                if (_map.ContainsKey (key)) {
+			        parent = _map [key];
+			        if (parent.Item.Scope.Name != baseType.Scope.Name) {
+			            parent = null;
+			        }
+			    }
+			    return parent != null;
 			}
 
 			internal IEnumerable<TypeDefinition> GetOrderedList ()

--- a/Obfuscar/ObfuscationMap.cs
+++ b/Obfuscar/ObfuscationMap.cs
@@ -198,5 +198,16 @@ namespace Obfuscar
 
 			resources.Add (r);
 		}
+
+        public IEnumerable<Tuple<TypeKey, string>> FindClasses (string name)
+        {
+            foreach (var kvp in classMap) {
+                if (kvp.Value.Status == ObfuscationStatus.Renamed) {
+                    if (kvp.Value.StatusText.EndsWith(name, StringComparison.Ordinal)) {
+                        yield return new Tuple<TypeKey, string> (kvp.Key, kvp.Value.StatusText);
+                    }
+                }
+            }
+        }
 	}
 }

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -20,9 +20,6 @@
 /// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 /// THE SOFTWARE.
 /// </copyright>
-using Mono.Cecil.Rocks;
-
-
 #endregion
 using System;
 using System.Collections;
@@ -33,6 +30,7 @@ using System.IO;
 using System.Linq;
 using System.Resources;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Linq;
 
@@ -41,6 +39,7 @@ using ILSpy.BamlDecompiler;
 #endif
 using Mono.Cecil;
 using Mono.Cecil.Cil;
+using Mono.Cecil.Rocks;
 using Obfuscar.Helpers;
 
 #if !__MonoCS__
@@ -206,31 +205,50 @@ namespace Obfuscar
 			// save the modified assemblies
 			foreach (AssemblyInfo info in Project) {
 				var fileName = Path.GetFileName (info.Filename);
-				// ReSharper disable once InvocationIsSkipped
-				Debug.Assert (fileName != null, "fileName != null");
-				// ReSharper disable once AssignNullToNotNullAttribute
-				string outName = Path.Combine (outPath, fileName);
-				var parameters = new WriterParameters ();
-				if (Project.Settings.RegenerateDebugInfo)
-					parameters.SymbolWriterProvider = new Mono.Cecil.Pdb.PdbWriterProvider ();
+                try {
+				    // ReSharper disable once InvocationIsSkipped
+				    Debug.Assert (fileName != null, "fileName != null");
+				    // ReSharper disable once AssignNullToNotNullAttribute
+				    string outName = Path.Combine (outPath, fileName);
+				    var parameters = new WriterParameters ();
+				    if (Project.Settings.RegenerateDebugInfo)
+					    parameters.SymbolWriterProvider = new Mono.Cecil.Pdb.PdbWriterProvider ();
 
-				if (info.Definition.Name.HasPublicKey) {
-					if (Project.KeyContainerName != null) {
-						info.Definition.Write (outName, parameters);
-						MsNetSigner.SignAssemblyFromKeyContainer (outName, Project.KeyContainerName);
-					}
+				    if (info.Definition.Name.HasPublicKey) {
+					    if (Project.KeyContainerName != null) {
+						    info.Definition.Write (outName, parameters);
+						    MsNetSigner.SignAssemblyFromKeyContainer (outName, Project.KeyContainerName);
+					    }
 
-					if (Project.KeyPair != null) {
-						parameters.StrongNameKeyPair = new System.Reflection.StrongNameKeyPair (Project.KeyPair);
-						info.Definition.Write (outName, parameters);
-					}
-				} else {
-					info.Definition.Write (outName, parameters);
-				}
+					    if (Project.KeyPair != null) {
+						    parameters.StrongNameKeyPair = new System.Reflection.StrongNameKeyPair (Project.KeyPair);
+						    info.Definition.Write (outName, parameters);
+					    }
+				    } else {
+					    info.Definition.Write (outName, parameters);
+				    }
+                } catch (Exception e) { 
+                    LogOutput (String.Format ("\nFailed to save {0}", fileName));
+                    LogOutput (String.Format ("\n{0}: {1}", e.GetType ().Name, e.Message));
+                    var match = Regex.Match (e.Message, @"Failed to resolve\s+(?<name>[^\s]+)");
+                    if (match.Success) {
+                        var name = match.Groups["name"].Value;
+                        LogOutput (String.Format ("\n{0} might be one of:", name));
+                        LogMappings (name);
+                        LogOutput ("\nHint: you might need to add a SkipType for an enum above.");
+                    }
+                }
 			}
 
 			TypeNameCache.nameCache.Clear ();
 		}
+
+        private void LogMappings (string name)
+        {
+            foreach (var tuple in Mapping.FindClasses (name)) {
+                LogOutput (String.Format ("\n{0} => {1}", tuple.Item1.Fullname, tuple.Item2));
+            }
+        }
 
 		/// <summary>
 		/// Saves the name mapping to the output path.

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -288,7 +288,11 @@ namespace Obfuscar
 		/// </summary>
 		public void RenameFields ()
 		{
-			foreach (var info in Project) {
+            if (!Project.Settings.RenameFields) {
+                return;
+            }
+
+            foreach (var info in Project) {
 				// loop through the types
 				foreach (var type in info.GetAllTypeDefinitions()) {
 					if (type.FullName == "<Module>") {

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -1092,6 +1092,8 @@ namespace Obfuscar
 				references.Add (info);
 			}
 
+            var generics = new List<GenericInstanceMethod> ();
+
 			foreach (AssemblyInfo reference in references) {
 				for (int i = 0; i < reference.UnrenamedReferences.Count;) {
 					MethodReference member = reference.UnrenamedReferences [i] as MethodReference;
@@ -1101,7 +1103,7 @@ namespace Obfuscar
 							if (generic == null) {
 								member.Name = newName;
 							} else {
-								generic.ElementMethod.Name = newName;
+                                generics.Add (generic);
 							}
 
 							reference.UnrenamedReferences.RemoveAt (i);
@@ -1114,6 +1116,10 @@ namespace Obfuscar
 					i++;
 				}
 			}
+
+            foreach (var generic in generics) {
+                generic.ElementMethod.Name = newName;
+            }
 
 			method.Name = newName;
 

--- a/Obfuscar/Settings.cs
+++ b/Obfuscar/Settings.cs
@@ -34,6 +34,7 @@ namespace Obfuscar
 		string outPath;
 		string logFilePath;
 		bool markedOnly;
+	    bool renameFields;
 		bool renameProperties;
 		bool renameEvents;
 		bool keepPublicApi;
@@ -55,6 +56,7 @@ namespace Obfuscar
 			logFilePath = Environment.ExpandEnvironmentVariables (vars.GetValue ("LogFile", ""));
 			markedOnly = XmlConvert.ToBoolean (vars.GetValue ("MarkedOnly", "false"));
 
+            renameFields = XmlConvert.ToBoolean (vars.GetValue("RenameFields", "true"));
 			renameProperties = XmlConvert.ToBoolean (vars.GetValue ("RenameProperties", "true"));
 			renameEvents = XmlConvert.ToBoolean (vars.GetValue ("RenameEvents", "true"));
 			keepPublicApi = XmlConvert.ToBoolean (vars.GetValue ("KeepPublicApi", "true"));
@@ -90,6 +92,10 @@ namespace Obfuscar
 
 		public string LogFilePath {
 			get { return logFilePath; }
+		}
+
+        public bool RenameFields {
+			get { return renameFields; }
 		}
 
 		public bool RenameProperties {

--- a/Tests/AutoSkipTypeTests.cs
+++ b/Tests/AutoSkipTypeTests.cs
@@ -227,5 +227,32 @@ namespace ObfuscarTests
 			var enum1 = map.GetClass (new TypeKey (enumType));
 			Assert.True (enum1.Status == ObfuscationStatus.Skipped, "Internal enum is obfuscated");
 		}
-	}
+
+        [Fact]
+        public void CheckSkipAllEnums ()
+        {
+            string xml = String.Format (
+                                      @"<?xml version='1.0'?>" +
+                                      @"<Obfuscator>" +
+                                      @"<Var name='InPath' value='{0}' />" +
+                                      @"<Var name='OutPath' value='{1}' />" +
+                                      @"<Var name='KeepPublicApi' value='false' />" +
+                                      @"<Var name='HidePrivateApi' value='true' />" +
+                                      @"<Module file='$(InPath)\AssemblyWithTypes.dll'>" +
+                                      @"<SkipEnums value='true' />" +
+                                      @"</Module>" +
+                                      @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
+
+            Obfuscator obfuscator = TestHelper.BuildAndObfuscate ("AssemblyWithTypes", string.Empty, xml);
+            var map = obfuscator.Mapping;
+
+            string assmName = "AssemblyWithTypes.dll";
+
+            var inAssmDef = AssemblyDefinition.ReadAssembly (Path.Combine (TestHelper.InputPath, assmName));
+
+            var enumType = inAssmDef.MainModule.GetType ("TestClasses.TestEnum");
+            var enum1 = map.GetClass (new TypeKey (enumType));
+            Assert.True (enum1.Status == ObfuscationStatus.Skipped, "Internal enum is obfuscated");
+        }
+    }
 }

--- a/Tests/CleanPoolTests.cs
+++ b/Tests/CleanPoolTests.cs
@@ -1,0 +1,53 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+using System;
+using Xunit;
+
+namespace ObfuscarTests
+{
+	public class CleanPoolTests
+	{
+		public void BuildAndObfuscateAssemblies()
+		{
+			string xml = String.Format (
+				@"<?xml version='1.0'?>" +
+				@"<Obfuscator>" +
+				@"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='ReuseNames' value='true' />" +
+                @"<Var name='KeepPublicApi' value='false' />" +
+                @"<Module file='$(InPath)\AssemblyForCleanPoolClass.dll' />" +
+                @"<Module file='$(InPath)\AssemblyForCleanPoolInterface.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
+
+			TestHelper.BuildAndObfuscate (new[] { "AssemblyForCleanPoolInterface", "AssemblyForCleanPoolClass" }, xml);
+        }
+
+		[Fact]
+		public void CheckCleanPool ()
+		{
+			BuildAndObfuscateAssemblies ();
+		}
+	}
+}

--- a/Tests/Input/AssemblyForCleanPoolClass.cs
+++ b/Tests/Input/AssemblyForCleanPoolClass.cs
@@ -1,0 +1,30 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+namespace TestClasses
+{
+    public class Alpha : IAlpha
+    {
+    }
+}

--- a/Tests/Input/AssemblyForCleanPoolInterface.cs
+++ b/Tests/Input/AssemblyForCleanPoolInterface.cs
@@ -1,0 +1,30 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+namespace TestClasses
+{
+    public interface IAlpha
+    {
+    }
+}

--- a/Tests/Input/AssemblyWithGenericOverrides.cs
+++ b/Tests/Input/AssemblyWithGenericOverrides.cs
@@ -1,0 +1,59 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+namespace TestClasses
+{
+    public interface IAlpha<T> { }
+    public interface IBeta<T1, T2> { }
+    public class Alpha<T> : IAlpha<T>
+    {
+        public Alpha (T i)
+        {
+            Item = i;
+        }
+        public T Item;
+        public override string ToString ()
+        {
+            return string.Format ("A<{0}>", Item);
+        }
+    }
+    public class Beta<T1, T2> : IBeta<T1, T2>
+    {
+        public override string ToString()
+        {
+            return string.Format ("B<{0}, {1}>", typeof(T1).Name, typeof(T2).Name);
+        }
+    }
+    public static class Generic
+    {
+        public static IAlpha<IBeta<C, int>> Empty<C> ()
+        {
+            return Empty<C, int> ();
+        }
+        public static IAlpha<IBeta<C, D>> Empty<C, D> ()
+        {
+            return new Alpha<IBeta<C, D>> ((IBeta<C, D>) new Beta<C, D> ());
+        }
+    }
+}

--- a/Tests/Input/AssemblyWithGenericOverrides2.cs
+++ b/Tests/Input/AssemblyWithGenericOverrides2.cs
@@ -1,0 +1,34 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+namespace TestClasses
+{
+    public class Test
+    {
+        public override string ToString ()
+        {
+            return string.Format ("Empty<string, string>={0}", Generic.Empty<string, string> ());
+        }
+    }
+}

--- a/Tests/ObfuscarTests.csproj
+++ b/Tests/ObfuscarTests.csproj
@@ -95,6 +95,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyHelper.cs" />
+    <Compile Include="CleanPoolTests.cs" />
     <Compile Include="AttributeTests.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Tests/SkipEnumTests.cs
+++ b/Tests/SkipEnumTests.cs
@@ -190,5 +190,32 @@ namespace ObfuscarTests
 
             CheckEnums ("AssemblyWithEnums", 1, expected, notExpected);
         }
-	}
+        
+        [Fact]
+        public void CheckSkipAllEnums ()
+        {
+            string xml = String.Format (
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Module file='$(InPath)\AssemblyWithEnums.dll'>" +
+                @"<SkipEnums value='true' />" +
+                @"</Module>" +
+                @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
+
+            TestHelper.BuildAndObfuscate ("AssemblyWithEnums", String.Empty, xml);
+
+            string[] expected = new string[] {
+                "Value1",
+                "Value2",
+                "ValueA"
+            };
+
+            string[] notExpected = new string[] {
+            };
+
+            CheckEnums ("AssemblyWithEnums", 1, expected, notExpected);
+        }
+    }
 }

--- a/Tests/SkipEnumTests.cs
+++ b/Tests/SkipEnumTests.cs
@@ -164,5 +164,31 @@ namespace ObfuscarTests
 
 			CheckEnums( "AssemblyWithEnums", 1, expected, notExpected );
 		}
+
+        [Fact]
+        public void CheckSkipAllFields ()
+        {
+            string xml = String.Format (
+                @"<?xml version='1.0'?>" +
+                @"<Obfuscator>" +
+                @"<Var name='InPath' value='{0}' />" +
+                @"<Var name='OutPath' value='{1}' />" +
+                @"<Var name='RenameFields' value='false' />" +
+                @"<Module file='$(InPath)\AssemblyWithEnums.dll' />" +
+                @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
+
+            TestHelper.BuildAndObfuscate ("AssemblyWithEnums", String.Empty, xml);
+
+            string[] expected = new string[] {
+                "Value1",
+                "Value2",
+                "ValueA"
+            };
+
+            string[] notExpected = new string[] {
+            };
+
+            CheckEnums ("AssemblyWithEnums", 1, expected, notExpected);
+        }
 	}
 }


### PR DESCRIPTION
Add RenameFields setting, useful when working on large projects. Renaming fields takes a lot of time. Being able to disable it temporarily is useful.

Fix some Re# warnings.

Add SkipEnums in module settings. When a large assembly has a lot of serialized enums, it is simpler to disable them all with one setting.

Add log to help diagnose assembly saving failures.

Fix CleanPool infinite loop in AssemblyInfo when obfuscated types is related to another obfuscated type with the same new name but in another assembly.

Fix MissingMethodException in strange generic method override case. Updating ElementMethod asap has a strange side effect that also updates name in methodKey and prevents matching other method references.

I tried to follow the coding style.