### PR TITLE
Fix method grouping when closed method overrides generic method.

### DIFF
--- a/Obfuscar/InheritMap.cs
+++ b/Obfuscar/InheritMap.cs
@@ -137,7 +137,8 @@ namespace Obfuscar
 
 		static bool MethodsMatch (MethodKey left, MethodKey right)
 		{
-			return MethodKey.MethodMatch (left.Method, right.Method);
+			return MethodKey.MethodMatch (left.Method, right.Method)
+                || MethodKey.MethodMatch (right.Method, left.Method);
 		}
 
 		public static void GetBaseTypes (Project project, HashSet<TypeKey> baseTypes, TypeDefinition type)

--- a/Tests/FunctionOverridingTests.cs
+++ b/Tests/FunctionOverridingTests.cs
@@ -182,7 +182,7 @@ namespace ObfuscarTests
                              @"</Module>" +
                              @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
 
-            Obfuscator obfuscator = TestHelper.BuildAndObfuscate(new[] { "AssemblyWithGenericOverrides", "AssemblyWithGenericOverrides2" }, xml);
+            TestHelper.BuildAndObfuscate(new[] { "AssemblyWithGenericOverrides", "AssemblyWithGenericOverrides2" }, xml);
 
             var assembly2Path = Path.Combine (Directory.GetCurrentDirectory (), TestHelper.OutputPath, "AssemblyWithGenericOverrides2.dll");
             var assembly2 = Assembly.LoadFile (assembly2Path);
@@ -199,13 +199,33 @@ namespace ObfuscarTests
             }
         }
 
-        private Assembly AssemblyResolve(object sender, ResolveEventArgs args)
+        private static Assembly AssemblyResolve(object sender, ResolveEventArgs args)
         {
             var assemblyPath = Path.Combine(Directory.GetCurrentDirectory (), TestHelper.OutputPath, args.Name.Split (',')[0] + ".dll");
             if (File.Exists (assemblyPath)) {
                 return Assembly.LoadFile (assemblyPath);
             }
             return null;
+        }
+
+        [Fact]
+        public void CheckClosedMethodOverrideGenericMethod ()
+        {
+            string xml = String.Format(
+                             @"<?xml version='1.0'?>" +
+                             @"<Obfuscator>" +
+                             @"<Var name='InPath' value='{0}' />" +
+                             @"<Var name='OutPath' value='{1}' />" +
+                             @"<Var name='KeepPublicApi' value='false' />" +
+                             @"<Var name='HidePrivateApi' value='true' />" +
+                             @"<Module file='$(InPath)\AssemblyWithClosedOverrideGeneric.dll' />" +
+                             @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath);
+
+            TestHelper.BuildAndObfuscate ("AssemblyWithClosedOverrideGeneric", string.Empty, xml);
+
+            var assemblyPath = Path.Combine (Directory.GetCurrentDirectory (), TestHelper.OutputPath, "AssemblyWithClosedOverrideGeneric.dll");
+            var assembly = Assembly.LoadFile (assemblyPath);
+            Assert.Equal (5, assembly.GetTypes ().Length);
         }
     }
 }

--- a/Tests/Input/AssemblyWithClosedOverrideGeneric.cs
+++ b/Tests/Input/AssemblyWithClosedOverrideGeneric.cs
@@ -1,0 +1,79 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+
+namespace TestClasses
+{
+    public interface IFoo { }
+    public interface IFoos : IEnumerable<IFoo>
+    {
+        IFoo[] ToArray ();
+    }
+    public class ClosedFoos : IFoos
+    {
+        public IFoo[] ToArray ()
+        {
+            throw new NotImplementedException ();
+        }
+        IEnumerator IEnumerable.GetEnumerator ()
+        {
+            return GetEnumerator ();
+        }
+        public IEnumerator<IFoo> GetEnumerator ()
+        {
+            throw new NotImplementedException ();
+        }
+    }
+    public abstract class Generic<T> : IEnumerable<T> where T : class, IFoo
+    {
+        IEnumerator IEnumerable.GetEnumerator ()
+        {
+            return GetEnumerator();
+        }
+        public abstract IEnumerator<T> GetEnumerator ();
+        public void Some ()
+        {
+        }
+        public void Other ()
+        {
+        }
+        public void Method ()
+        {
+        }
+        public T[] ToArray ()
+        {
+            throw new NotImplementedException ();
+        }
+    }
+    public class Foos : Generic<IFoo>, IFoos
+    {
+        public override IEnumerator<IFoo> GetEnumerator ()
+        {
+            throw new NotImplementedException ();
+        }
+    }
+}


### PR DESCRIPTION
Cf unit test : without fix, Generic.ToArray method was not renamed in the same group as other ToArray methods.

Matching methods left vs right **and** right vs left might not be very efficient. But other attempts to fix the symetry problem added other bugs.