### PR TITLE
Fix for assemblies compiled by NETCore SDK #85

### DIFF
--- a/Obfuscar/Helpers/AssemblyDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/AssemblyDefinitionExtensions.cs
@@ -11,6 +11,8 @@ namespace Obfuscar.Helpers
 		{
 			foreach (var custom in assembly.CustomAttributes) {
 				if (custom.AttributeType.FullName == "System.Runtime.Versioning.TargetFrameworkAttribute") {
+					if (custom.Properties.Count==0) 
+						continue;
 					var framework = custom.Properties.First(property => property.Name == "FrameworkDisplayName");
 					var content = framework.Argument.Value.ToString ();
 					if (!string.Equals (content, ".NET Portable Subset")) {

--- a/Obfuscar/Helpers/AssemblyDefinitionExtensions.cs
+++ b/Obfuscar/Helpers/AssemblyDefinitionExtensions.cs
@@ -11,7 +11,7 @@ namespace Obfuscar.Helpers
 		{
 			foreach (var custom in assembly.CustomAttributes) {
 				if (custom.AttributeType.FullName == "System.Runtime.Versioning.TargetFrameworkAttribute") {
-					if (custom.Properties.Count==0) 
+					if (!custom.HasProperties) 
 						continue;
 					var framework = custom.Properties.First(property => property.Name == "FrameworkDisplayName");
 					var content = framework.Argument.Value.ToString ();


### PR DESCRIPTION
Workaround for 'Sequence contains no matching elements' is straightforward (test custom.Properties.Count for 0 before .First() call). After this change I was able to obfuscate assemblies produced by 'dotnet build' (both net40 and netstandard15 builds).