### PR TITLE
Fix NRE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ T4MVC.cs
 
 *.iml
 .idea/
+.vs

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -336,7 +336,7 @@ namespace Obfuscar
 						customattributearguments.Add (namedargument.Argument);
 
 					foreach (CustomAttributeArgument ca in customattributearguments) {
-						if (ca.Type.FullName == "System.Type")
+						if (ca.Type.FullName == "System.Type" && ca.Value != null)
 							typerefs.Add ((TypeReference)ca.Value);
 					}
 				}

--- a/Tests/CustomAttributeWithArgTests.cs
+++ b/Tests/CustomAttributeWithArgTests.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.IO;
+using Mono.Cecil;
+using Xunit;
+
+namespace ObfuscarTests
+{
+	public class CustomAttributeWithArgTests
+	{
+		public CustomAttributeWithArgTests()
+		{
+			var xml = String.Format (
+				             @"<?xml version='1.0'?>" +
+				             @"<Obfuscator>" +
+				             @"<Var name='InPath' value='{0}' />" +
+				             @"<Var name='OutPath' value='{1}' />" +
+							 @"<Var name='KeepPublicApi' value='false' />" +
+				             @"<Var name='HidePrivateApi' value='true' />" +
+				             @"<Module file='$(InPath){2}AssemblyWithCustomAttrTypeArg.dll' />" +
+				             @"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar);
+
+			TestHelper.BuildAndObfuscate ("AssemblyWithCustomAttrTypeArg", String.Empty, xml);
+		}
+
+		[Fact]
+		public void Check_for_null ()
+		{
+			var assmDef = AssemblyDefinition.ReadAssembly (
+				                             Path.Combine (TestHelper.OutputPath, "AssemblyWithCustomAttrTypeArg.dll"));
+
+			Assert.Equal (3, assmDef.MainModule.Types.Count);
+		}
+	}
+}

--- a/Tests/Input/AssemblyWithCustomAttrTypeArg.cs
+++ b/Tests/Input/AssemblyWithCustomAttrTypeArg.cs
@@ -1,0 +1,45 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// 
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+/// 
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+/// 
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace TestClasses
+{
+	[CustomAttribute]
+	public class ClassA
+	{
+	}
+
+	internal class CustomAttribute : Attribute
+	{
+		public CustomAttribute(Type typeRef = null)
+		{
+			TypeRef = typeRef;
+		}
+
+		public Type TypeRef { get; private set; }
+	}
+}

--- a/Tests/ObfuscarTests.csproj
+++ b/Tests/ObfuscarTests.csproj
@@ -101,6 +101,7 @@
     </Compile>
     <Compile Include="AutoSkipTypeTests.cs" />
     <Compile Include="BamlTests.cs" />
+    <Compile Include="CustomAttributeWithArgTests.cs" />
     <Compile Include="DelaySignedTests.cs" />
     <Compile Include="DockPanelSuiteTests.cs" />
     <Compile Include="FSharpTests.cs" />


### PR DESCRIPTION
NullReferencesException occurs on custom attribute processing if
attribute have argument with type Syste.Type and default value null