### PR TITLE
Added tag for extra assembly search path

### DIFF
--- a/Obfuscar/AssemblyCache.cs
+++ b/Obfuscar/AssemblyCache.cs
@@ -35,8 +35,7 @@ namespace Obfuscar
 
 		public AssemblyCache (Project project)
 		{
-			AddSearchDirectory (project.Settings.InPath);
-			foreach (var path in project.ExtraPaths)
+			foreach (var path in project.AssemblySearchPaths)
 				AddSearchDirectory (path);
 
 			foreach (AssemblyInfo info in project)

--- a/Obfuscar/Helpers/ILProcessorExtensions.cs
+++ b/Obfuscar/Helpers/ILProcessorExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Obfuscar.Helpers
+{
+	static class ILProcessorExtensions
+	{
+		public static Instruction ReplaceAndFixReferences(this ILProcessor processor, Instruction oldInstruction, Instruction newInstruction)
+		{
+			newInstruction.Offset = oldInstruction.Offset;
+			processor.Replace(oldInstruction, newInstruction);
+			foreach (Instruction bodyInstruction in processor.Body.Instructions)
+			{
+				ReplaceOperandInstruction(bodyInstruction, oldInstruction, newInstruction);
+			}
+
+			foreach (ExceptionHandler exceptionHandler in processor.Body.ExceptionHandlers)
+			{
+				ReplaceInstruction(
+					() => exceptionHandler.FilterStart,
+					instruction => exceptionHandler.FilterStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.HandlerStart,
+					instruction => exceptionHandler.HandlerStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.HandlerEnd,
+					instruction => exceptionHandler.HandlerEnd = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.TryStart,
+					instruction => exceptionHandler.TryStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.TryEnd,
+					instruction => exceptionHandler.TryEnd = instruction,
+					oldInstruction,
+					newInstruction);
+			}
+
+			return newInstruction;
+		}
+
+		private static void ReplaceInstruction(
+			Func<Instruction> getInstruction,
+			Action<Instruction> setInstruction,
+			Instruction oldInstruction,
+			Instruction newInstruction)
+		{
+			if (getInstruction() == oldInstruction) {
+				setInstruction(newInstruction);
+			}
+		}
+
+		private static void ReplaceOperandInstruction(Instruction bodyInstruction, Instruction oldInstruction, Instruction newInstruction)
+		{
+			if (bodyInstruction == null)
+				return;
+
+			if (bodyInstruction.Operand == oldInstruction) {
+				bodyInstruction.Operand = newInstruction;
+			}
+		}
+	}
+}

--- a/Obfuscar/Obfuscar.csproj
+++ b/Obfuscar/Obfuscar.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Helpers\EventDefinitionExtensions.cs" />
     <Compile Include="Helpers\MethodDefinitionExtensions.cs" />
     <Compile Include="Helpers\PropertyDefinitionExtensions.cs" />
+    <Compile Include="Helpers\ILProcessorExtensions.cs" />
     <Compile Include="Helpers\TypeReferenceExtensions.cs" />
     <Compile Include="NamespaceTester.cs" />
     <Compile Include="ObfuscarException.cs" />

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -63,7 +63,7 @@ namespace Obfuscar
 			}
 		}
 
-		public IEnumerable<string> AssemblySearchPaths {
+		public IEnumerable<string> AllAssemblySearchPaths {
 			get {
 				return
 					ExtraPaths

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -59,11 +59,16 @@ namespace Obfuscar
 
 		public IEnumerable<string> ExtraPaths {
 			get {
+				return vars.GetValue ("ExtraFrameworkFolders", "").Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+			}
+		}
+
+		public IEnumerable<string> AssemblySearchPaths {
+			get {
 				return
-					vars
-					.GetValue ("ExtraFrameworkFolders", "")
-					.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
-					.Concat(assemblySearchPaths);
+					ExtraPaths
+						.Concat(assemblySearchPaths)
+						.Concat(new[] { Settings.InPath });
 			}
 		}
 
@@ -110,8 +115,8 @@ namespace Obfuscar
 					KeyContainerName = vars.GetValue ("KeyContainer", null);
 					if (Type.GetType ("System.MonoType") != null)
 						throw new ObfuscarException ("Key containers are not supported for Mono.");
-				} 
-   				
+				}
+
 				return null;
 				//return keyvalue;
 			}
@@ -246,6 +251,12 @@ namespace Obfuscar
 		/// </summary>
 		public void CheckSettings ()
 		{
+			foreach (string assemblySearchPath in assemblySearchPaths)
+			{
+				if (!Directory.Exists (assemblySearchPath))
+					throw new ObfuscarException ("Path specified by AssemblySearchPath must exist:" + assemblySearchPath);
+			}
+
 			if (!Directory.Exists (Settings.InPath))
 				throw new ObfuscarException ("Path specified by InPath variable must exist:" + Settings.InPath);
 

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -47,6 +47,7 @@ namespace Obfuscar
 		private readonly List<AssemblyInfo> copyAssemblyList = new List<AssemblyInfo> ();
 		private readonly Dictionary<string, AssemblyInfo> assemblyMap = new Dictionary<string, AssemblyInfo> ();
 		private readonly Variables vars = new Variables ();
+		private readonly List<string> assemblySearchPaths = new List<string>();
 		InheritMap inheritMap;
 		Settings settings;
 		// FIXME: Figure out why this exists if it is never used.
@@ -56,9 +57,13 @@ namespace Obfuscar
 		{
 		}
 
-		public string [] ExtraPaths {
+		public IEnumerable<string> ExtraPaths {
 			get {
-				return vars.GetValue ("ExtraFrameworkFolders", "").Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+				return
+					vars
+					.GetValue ("ExtraFrameworkFolders", "")
+					.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
+					.Concat(assemblySearchPaths);
 			}
 		}
 
@@ -155,6 +160,10 @@ namespace Obfuscar
 						Console.WriteLine ("Processing assembly: " + info.Definition.Name.FullName);
 						project.assemblyList.Add (info);
 						project.assemblyMap [info.Name] = info;
+						break;
+					case "AssemblySearchPath":
+						string path = project.vars.Replace(Helper.GetAttribute(reader, "path"));
+						project.assemblySearchPaths.Add(path);
 						break;
 					}
 				}

--- a/Tests/HideStringsTests.cs
+++ b/Tests/HideStringsTests.cs
@@ -30,7 +30,7 @@ namespace ObfuscarTests
 {
 	public class HideStringsTests
 	{
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassDoesNotExist ()
 		{
 			string xml = string.Format (
@@ -58,7 +58,7 @@ namespace ObfuscarTests
 			Assert.Null (expected);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassExists ()
 		{
 			string xml = string.Format (
@@ -90,7 +90,7 @@ namespace ObfuscarTests
 			Assert.Equal (6, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassSkip ()
 		{
 			string xml = string.Format (
@@ -124,7 +124,7 @@ namespace ObfuscarTests
 			Assert.Equal (4, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassForce ()
 		{
 			string xml = string.Format (
@@ -158,7 +158,7 @@ namespace ObfuscarTests
 			Assert.Equal (4, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassForce2 ()
 		{
 			string xml = string.Format (

--- a/ThirdParty/SharedAssemblyInfo.cs
+++ b/ThirdParty/SharedAssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Reflection;
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
 
-[assembly: AssemblyVersion("2.2.040408.07")]
+[assembly: AssemblyVersion("2.2.040430.08")]
 [assembly: AssemblyProduct("Obfuscar 2.2.4")]
 #if (!CF)
-[assembly: AssemblyFileVersion("2.2.040408.07")]
+[assembly: AssemblyFileVersion("2.2.040430.08")]
 #endif

--- a/ThirdParty/SharedAssemblyInfo.cs
+++ b/ThirdParty/SharedAssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Reflection;
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
 
-[assembly: AssemblyVersion("2.2.040430.08")]
+[assembly: AssemblyVersion("2.2.040501.01")]
 [assembly: AssemblyProduct("Obfuscar 2.2.4")]
 #if (!CF)
-[assembly: AssemblyFileVersion("2.2.040430.08")]
+[assembly: AssemblyFileVersion("2.2.040501.01")]
 #endif


### PR DESCRIPTION
Currently, referenced assembly are only searched at InPath. I've added a `<AssemblySearchPath>` tag that specifies an additional place to search for references. There can be multiple instances of this tag, of course. Usage example:
```
<?xml version='1.0'?>
<Obfuscator>
  <Var name="InPath" value=".\Assets\SpriteSharp\Editor" />
  <Var name="OutPath" value=".\Assets\SpriteSharp\Editor" />

  <Var name="KeepPublicApi" value="true" />

  <AssemblySearchPath path=".\Library\UnityAssemblies" />
  <AssemblySearchPath path=".\Assets\SpriteSharp\Editor\3rdParty" />

  <Module file="$(AssemblyPath)\LostPolygon.SpriteSharp.dll" />
</Obfuscator>
```