### PR TITLE
Fixed (?) and re-enabled string hiding

### DIFF
--- a/Obfuscar/Helpers/ILProcessorExtensions.cs
+++ b/Obfuscar/Helpers/ILProcessorExtensions.cs
@@ -63,8 +63,21 @@ namespace Obfuscar.Helpers
 			if (bodyInstruction == null)
 				return;
 
-			if (bodyInstruction.Operand == oldInstruction) {
+			Instruction instructionOperand = bodyInstruction.Operand as Instruction;
+			if (instructionOperand != null && instructionOperand == oldInstruction) {
 				bodyInstruction.Operand = newInstruction;
+				return;
+			}
+
+			Instruction[] instructionArrayOperand = bodyInstruction.Operand as Instruction[];
+			if (instructionArrayOperand != null) {
+				for (int i = 0; i < instructionArrayOperand.Length; i++) {
+					if (instructionArrayOperand[i] == oldInstruction) {
+						instructionArrayOperand[i] = newInstruction;
+					}
+				}
+
+				bodyInstruction.Operand = instructionArrayOperand;
 			}
 		}
 	}

--- a/Obfuscar/Helpers/ILProcessorExtensions.cs
+++ b/Obfuscar/Helpers/ILProcessorExtensions.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using Mono.Cecil;
+using Mono.Cecil.Cil;
+
+namespace Obfuscar.Helpers
+{
+	static class ILProcessorExtensions
+	{
+		public static Instruction ReplaceAndFixReferences(this ILProcessor processor, Instruction oldInstruction, Instruction newInstruction)
+		{
+			newInstruction.Offset = oldInstruction.Offset;
+			processor.Replace(oldInstruction, newInstruction);
+			foreach (Instruction bodyInstruction in processor.Body.Instructions)
+			{
+				ReplaceOperandInstruction(bodyInstruction, oldInstruction, newInstruction);
+			}
+
+			foreach (ExceptionHandler exceptionHandler in processor.Body.ExceptionHandlers)
+			{
+				ReplaceInstruction(
+					() => exceptionHandler.FilterStart,
+					instruction => exceptionHandler.FilterStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.HandlerStart,
+					instruction => exceptionHandler.HandlerStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.HandlerEnd,
+					instruction => exceptionHandler.HandlerEnd = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.TryStart,
+					instruction => exceptionHandler.TryStart = instruction,
+					oldInstruction,
+					newInstruction);
+				ReplaceInstruction(
+					() => exceptionHandler.TryEnd,
+					instruction => exceptionHandler.TryEnd = instruction,
+					oldInstruction,
+					newInstruction);
+			}
+
+			return newInstruction;
+		}
+
+		private static void ReplaceInstruction(
+			Func<Instruction> getInstruction,
+			Action<Instruction> setInstruction,
+			Instruction oldInstruction,
+			Instruction newInstruction)
+		{
+			if (getInstruction() == oldInstruction) {
+				setInstruction(newInstruction);
+			}
+		}
+
+		private static void ReplaceOperandInstruction(Instruction bodyInstruction, Instruction oldInstruction, Instruction newInstruction)
+		{
+			if (bodyInstruction == null)
+				return;
+
+			if (bodyInstruction.Operand == oldInstruction) {
+				bodyInstruction.Operand = newInstruction;
+			}
+		}
+	}
+}

--- a/Obfuscar/Helpers/ILProcessorExtensions.cs
+++ b/Obfuscar/Helpers/ILProcessorExtensions.cs
@@ -64,15 +64,19 @@ namespace Obfuscar.Helpers
 				return;
 
 			Instruction instructionOperand = bodyInstruction.Operand as Instruction;
-			if (instructionOperand != null && instructionOperand == oldInstruction) {
+			if (instructionOperand != null && instructionOperand == oldInstruction)
+			{
 				bodyInstruction.Operand = newInstruction;
 				return;
 			}
 
 			Instruction[] instructionArrayOperand = bodyInstruction.Operand as Instruction[];
-			if (instructionArrayOperand != null) {
-				for (int i = 0; i < instructionArrayOperand.Length; i++) {
-					if (instructionArrayOperand[i] == oldInstruction) {
+			if (instructionArrayOperand != null)
+			{
+				for (int i = 0; i < instructionArrayOperand.Length; i++)
+				{
+					if (instructionArrayOperand[i] == oldInstruction)
+					{
 						instructionArrayOperand[i] = newInstruction;
 					}
 				}

--- a/Obfuscar/Obfuscar.csproj
+++ b/Obfuscar/Obfuscar.csproj
@@ -70,6 +70,7 @@
     <Compile Include="Helpers\EventDefinitionExtensions.cs" />
     <Compile Include="Helpers\MethodDefinitionExtensions.cs" />
     <Compile Include="Helpers\PropertyDefinitionExtensions.cs" />
+    <Compile Include="Helpers\ILProcessorExtensions.cs" />
     <Compile Include="Helpers\TypeReferenceExtensions.cs" />
     <Compile Include="NamespaceTester.cs" />
     <Compile Include="ObfuscarException.cs" />

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -1,17 +1,17 @@
 #region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
 /// <copyright>
 /// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
-/// 
+///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
 /// in the Software without restriction, including without limitation the rights
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -1365,14 +1365,14 @@ namespace Obfuscar
 			{
 				if (!info.ShouldSkipStringHiding (new MethodKey (method), project.InheritMap, project.Settings.HideStrings) && method.Body != null) {
 					Initialize ();
-					
-					// IMPORTANT: cannot convert to foreach due to modification on method body.
-					// ReSharper disable once ForCanBeConvertedToForeach
 
 					// Unroll short form instructions so they can be auto-fixed by Cecil
-					// automatically when new instructions are inserted/replaced
+					// automatically when instructions are inserted/replaced
 					method.Body.SimplifyMacros();
 					ILProcessor worker = method.Body.GetILProcessor ();
+
+					// IMPORTANT: cannot convert to foreach due to modification on method body.
+					// ReSharper disable once ForCanBeConvertedToForeach
 					for (int index = 0; index < method.Body.Instructions.Count; index++) {
 						Instruction instruction = method.Body.Instructions [index];
 						if (instruction.OpCode == OpCodes.Ldstr) {

--- a/Tests/HideStringsTests.cs
+++ b/Tests/HideStringsTests.cs
@@ -30,7 +30,7 @@ namespace ObfuscarTests
 {
 	public class HideStringsTests
 	{
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassDoesNotExist ()
 		{
 			string xml = string.Format (
@@ -58,7 +58,7 @@ namespace ObfuscarTests
 			Assert.Null (expected);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassExists ()
 		{
 			string xml = string.Format (
@@ -90,7 +90,7 @@ namespace ObfuscarTests
 			Assert.Equal (6, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassSkip ()
 		{
 			string xml = string.Format (
@@ -124,7 +124,7 @@ namespace ObfuscarTests
 			Assert.Equal (4, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassForce ()
 		{
 			string xml = string.Format (
@@ -158,7 +158,7 @@ namespace ObfuscarTests
 			Assert.Equal (4, expected.Methods.Count);
 		}
 
-		//[Fact]
+		[Fact]
 		public void CheckHideStringsClassForce2 ()
 		{
 			string xml = string.Format (


### PR DESCRIPTION
As mentioned in https://github.com/lextm/obfuscar/commit/f364a38d511e9b77fd875dee5acb54e57cbe1c45, the string hiding feature is hidden because it leads to runtime crashes. And indeed, after re-enabling the feature in  the source code and using it on my project, I've noticed that IL generated by Obfuscar was utterly broken, since Obfuscar doesn't updates instruction references when replacing string load instruction. I've fixed that and everything seems to work fine for me.
I am not sure if the issue I've fixed *is* the issue that lead to disabling this feature completely, though. Can you verify?