### PR TITLE
Added tag for extra assembly search path

### DIFF
--- a/Obfuscar/AssemblyCache.cs
+++ b/Obfuscar/AssemblyCache.cs
@@ -35,8 +35,7 @@ namespace Obfuscar
 
 		public AssemblyCache (Project project)
 		{
-			AddSearchDirectory (project.Settings.InPath);
-			foreach (var path in project.ExtraPaths)
+			foreach (var path in project.AssemblySearchPaths)
 				AddSearchDirectory (path);
 
 			foreach (AssemblyInfo info in project)

--- a/Obfuscar/AssemblyCache.cs
+++ b/Obfuscar/AssemblyCache.cs
@@ -35,7 +35,7 @@ namespace Obfuscar
 
 		public AssemblyCache (Project project)
 		{
-			foreach (var path in project.AssemblySearchPaths)
+			foreach (var path in project.AllAssemblySearchPaths)
 				AddSearchDirectory (path);
 
 			foreach (AssemblyInfo info in project)

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -1,17 +1,17 @@
 #region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
 /// <copyright>
 /// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
-/// 
+///
 /// Permission is hereby granted, free of charge, to any person obtaining a copy
 /// of this software and associated documentation files (the "Software"), to deal
 /// in the Software without restriction, including without limitation the rights
 /// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 /// copies of the Software, and to permit persons to whom the Software is
 /// furnished to do so, subject to the following conditions:
-/// 
+///
 /// The above copyright notice and this permission notice shall be included in
 /// all copies or substantial portions of the Software.
-/// 
+///
 /// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 /// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 /// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -167,7 +167,7 @@ namespace Obfuscar
 						project.assemblyMap [info.Name] = info;
 						break;
 					case "AssemblySearchPath":
-						string path = project.vars.Replace(Helper.GetAttribute(reader, "path"));
+						string path = Environment.ExpandEnvironmentVariables(project.vars.Replace(Helper.GetAttribute(reader, "path")));
 						project.assemblySearchPaths.Add(path);
 						break;
 					}

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -63,7 +63,7 @@ namespace Obfuscar
 			}
 		}
 
-		public IEnumerable<string> AssemblySearchPaths {
+		public IEnumerable<string> AllAssemblySearchPaths {
 			get {
 				return
 					ExtraPaths

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -59,11 +59,16 @@ namespace Obfuscar
 
 		public IEnumerable<string> ExtraPaths {
 			get {
+				return vars.GetValue ("ExtraFrameworkFolders", "").Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+			}
+		}
+
+		public IEnumerable<string> AssemblySearchPaths {
+			get {
 				return
-					vars
-					.GetValue ("ExtraFrameworkFolders", "")
-					.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
-					.Concat(assemblySearchPaths);
+					ExtraPaths
+						.Concat(assemblySearchPaths)
+						.Concat(new[] { Settings.InPath });
 			}
 		}
 
@@ -110,8 +115,8 @@ namespace Obfuscar
 					KeyContainerName = vars.GetValue ("KeyContainer", null);
 					if (Type.GetType ("System.MonoType") != null)
 						throw new ObfuscarException ("Key containers are not supported for Mono.");
-				} 
-   				
+				}
+
 				return null;
 				//return keyvalue;
 			}
@@ -246,6 +251,12 @@ namespace Obfuscar
 		/// </summary>
 		public void CheckSettings ()
 		{
+			foreach (string assemblySearchPath in assemblySearchPaths)
+			{
+				if (!Directory.Exists (assemblySearchPath))
+					throw new ObfuscarException ("Path specified by AssemblySearchPath must exist:" + assemblySearchPath);
+			}
+
 			if (!Directory.Exists (Settings.InPath))
 				throw new ObfuscarException ("Path specified by InPath variable must exist:" + Settings.InPath);
 

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -47,6 +47,7 @@ namespace Obfuscar
 		private readonly List<AssemblyInfo> copyAssemblyList = new List<AssemblyInfo> ();
 		private readonly Dictionary<string, AssemblyInfo> assemblyMap = new Dictionary<string, AssemblyInfo> ();
 		private readonly Variables vars = new Variables ();
+		private readonly List<string> assemblySearchPaths = new List<string>();
 		InheritMap inheritMap;
 		Settings settings;
 		// FIXME: Figure out why this exists if it is never used.
@@ -56,9 +57,13 @@ namespace Obfuscar
 		{
 		}
 
-		public string [] ExtraPaths {
+		public IEnumerable<string> ExtraPaths {
 			get {
-				return vars.GetValue ("ExtraFrameworkFolders", "").Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries);
+				return
+					vars
+					.GetValue ("ExtraFrameworkFolders", "")
+					.Split (new char [] { Path.PathSeparator }, StringSplitOptions.RemoveEmptyEntries)
+					.Concat(assemblySearchPaths);
 			}
 		}
 
@@ -155,6 +160,10 @@ namespace Obfuscar
 						Console.WriteLine ("Processing assembly: " + info.Definition.Name.FullName);
 						project.assemblyList.Add (info);
 						project.assemblyMap [info.Name] = info;
+						break;
+					case "AssemblySearchPath":
+						string path = project.vars.Replace(Helper.GetAttribute(reader, "path"));
+						project.assemblySearchPaths.Add(path);
 						break;
 					}
 				}

--- a/ThirdParty/SharedAssemblyInfo.cs
+++ b/ThirdParty/SharedAssemblyInfo.cs
@@ -7,8 +7,8 @@ using System.Reflection;
 // You can specify all the values or you can use the default the Revision and
 // Build Numbers by using the '*' as shown below:
 
-[assembly: AssemblyVersion("2.2.040408.07")]
+[assembly: AssemblyVersion("2.2.040430.08")]
 [assembly: AssemblyProduct("Obfuscar 2.2.4")]
 #if (!CF)
-[assembly: AssemblyFileVersion("2.2.040408.07")]
+[assembly: AssemblyFileVersion("2.2.040430.08")]
 #endif


### PR DESCRIPTION
Currently, referenced assembly are only searched at InPath. I've added a `<AssemblySearchPath>` tag that specifies an additional place to search for references. There can be multiple instances of this tag, of course. Usage example:
```
<?xml version='1.0'?>
<Obfuscator>
  <Var name="InPath" value=".\Assets\SpriteSharp\Editor" />
  <Var name="OutPath" value=".\Assets\SpriteSharp\Editor" />

  <Var name="KeepPublicApi" value="true" />

  <AssemblySearchPath path=".\Library\UnityAssemblies" />
  <AssemblySearchPath path=".\Assets\SpriteSharp\Editor\3rdParty" />

  <Module file="$(AssemblyPath)\LostPolygon.SpriteSharp.dll" />
</Obfuscator>
```