### PR TITLE
Added <include> tag

### DIFF
--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -100,193 +100,239 @@ namespace Obfuscar
 			}
 
 			if (!reader.IsEmptyElement) {
-				while (reader.Read ()) {
-					if (reader.NodeType == XmlNodeType.Element) {
-						string name = Helper.GetAttribute (reader, "name", vars);
+				FromXmlReadNode(reader, project, vars, info);
+			}
 
-						string rxStr = Helper.GetAttribute (reader, "rx");
-						Regex rx = null;
-						if (!string.IsNullOrEmpty (rxStr)) {
-							rx = new Regex (rxStr);
+			return info;
+		}
+
+		private static void FromXmlReadNode(XmlReader reader, Project project, Variables vars, AssemblyInfo info)
+		{
+			string val;
+			while (reader.Read())
+			{
+				if (reader.NodeType == XmlNodeType.Element)
+				{
+					string name = Helper.GetAttribute(reader, "name", vars);
+
+					string rxStr = Helper.GetAttribute(reader, "rx");
+					Regex rx = null;
+					if (!string.IsNullOrEmpty(rxStr))
+					{
+						rx = new Regex(rxStr);
+					}
+
+					string isStaticStr = Helper.GetAttribute(reader, "static", vars);
+					bool? isStatic = null;
+					if (!string.IsNullOrEmpty(isStaticStr))
+					{
+						isStatic = XmlConvert.ToBoolean(isStaticStr);
+					}
+
+					string isSerializableStr = Helper.GetAttribute(reader, "serializable", vars);
+					bool? isSerializable = null;
+					if (!string.IsNullOrEmpty(isSerializableStr))
+					{
+						isSerializable = XmlConvert.ToBoolean(isSerializableStr);
+					}
+
+					string attrib = Helper.GetAttribute(reader, "attrib", vars);
+					string inherits = Helper.GetAttribute(reader, "typeinherits", vars);
+					string type = Helper.GetAttribute(reader, "type", vars);
+					string typeattrib = Helper.GetAttribute(reader, "typeattrib", vars);
+
+					switch (reader.Name)
+					{
+						case "Include":
+						{
+							Project.ReadIncludeTag(reader, project, (includeReader, proj) => FromXmlReadNode(includeReader, proj, vars, info));
+							break;
 						}
-
-						string isStaticStr = Helper.GetAttribute (reader, "static", vars);
-						bool? isStatic = null;
-						if (!string.IsNullOrEmpty (isStaticStr)) {
-							isStatic = XmlConvert.ToBoolean (isStaticStr);
-						}
-
-						string isSerializableStr = Helper.GetAttribute (reader, "serializable", vars);
-						bool? isSerializable = null;
-						if (!string.IsNullOrEmpty (isSerializableStr)) {
-							isSerializable = XmlConvert.ToBoolean (isSerializableStr);
-						}
-
-						string attrib = Helper.GetAttribute (reader, "attrib", vars);
-						string inherits = Helper.GetAttribute (reader, "typeinherits", vars);
-						string type = Helper.GetAttribute (reader, "type", vars);
-						string typeattrib = Helper.GetAttribute (reader, "typeattrib", vars);
-
-						switch (reader.Name) {
 						case "SkipNamespace":
-							if (rx != null) {
-								info.skipNamespaces.Add (new NamespaceTester (rx));
-							} else {
-								info.skipNamespaces.Add (new NamespaceTester (name));
+							if (rx != null)
+							{
+								info.skipNamespaces.Add(new NamespaceTester(rx));
+							} else
+							{
+								info.skipNamespaces.Add(new NamespaceTester(name));
 							}
 							break;
 						case "ForceNamespace":
-							if (rx != null) {
-								info.forceNamespaces.Add (new NamespaceTester (rx));
-							} else {
-								info.forceNamespaces.Add (new NamespaceTester (name));
+							if (rx != null)
+							{
+								info.forceNamespaces.Add(new NamespaceTester(rx));
+							} else
+							{
+								info.forceNamespaces.Add(new NamespaceTester(name));
 							}
 							break;
 						case "SkipType":
 							TypeAffectFlags skipFlags = TypeAffectFlags.SkipNone;
 
-							val = Helper.GetAttribute (reader, "skipMethods", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "skipMethods", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								skipFlags |= TypeAffectFlags.AffectMethod;
 
-							val = Helper.GetAttribute (reader, "skipStringHiding", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "skipStringHiding", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								skipFlags |= TypeAffectFlags.AffectString;
 
-							val = Helper.GetAttribute (reader, "skipFields", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "skipFields", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								skipFlags |= TypeAffectFlags.AffectField;
 
-							val = Helper.GetAttribute (reader, "skipProperties", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "skipProperties", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								skipFlags |= TypeAffectFlags.AffectProperty;
 
-							val = Helper.GetAttribute (reader, "skipEvents", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "skipEvents", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								skipFlags |= TypeAffectFlags.AffectEvent;
 
-							if (rx != null) {
-								info.skipTypes.Add (new TypeTester (rx, skipFlags, attrib, inherits, isStatic, isSerializable));
-							} else {
-								info.skipTypes.Add (new TypeTester (name, skipFlags, attrib, inherits, isStatic, isSerializable));
+							if (rx != null)
+							{
+								info.skipTypes.Add(new TypeTester(rx, skipFlags, attrib, inherits, isStatic, isSerializable));
+							} else
+							{
+								info.skipTypes.Add(new TypeTester(name, skipFlags, attrib, inherits, isStatic, isSerializable));
 							}
 							break;
 						case "ForceType":
 							TypeAffectFlags forceFlags = TypeAffectFlags.SkipNone;
 
-							val = Helper.GetAttribute (reader, "forceMethods", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "forceMethods", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								forceFlags |= TypeAffectFlags.AffectMethod;
 
-							val = Helper.GetAttribute (reader, "forceStringHiding", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "forceStringHiding", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								forceFlags |= TypeAffectFlags.AffectString;
 
-							val = Helper.GetAttribute (reader, "forceFields", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "forceFields", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								forceFlags |= TypeAffectFlags.AffectField;
 
-							val = Helper.GetAttribute (reader, "forceProperties", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "forceProperties", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								forceFlags |= TypeAffectFlags.AffectProperty;
 
-							val = Helper.GetAttribute (reader, "forceEvents", vars);
-							if (val.Length > 0 && XmlConvert.ToBoolean (val))
+							val = Helper.GetAttribute(reader, "forceEvents", vars);
+							if (val.Length > 0 && XmlConvert.ToBoolean(val))
 								forceFlags |= TypeAffectFlags.AffectEvent;
 
-							if (rx != null) {
-								info.forceTypes.Add (new TypeTester (rx, forceFlags, attrib, inherits, isStatic, isSerializable));
-							} else {
-								info.forceTypes.Add (new TypeTester (name, forceFlags, attrib, inherits, isStatic, isSerializable));
+							if (rx != null)
+							{
+								info.forceTypes.Add(new TypeTester(rx, forceFlags, attrib, inherits, isStatic, isSerializable));
+							} else
+							{
+								info.forceTypes.Add(new TypeTester(name, forceFlags, attrib, inherits, isStatic, isSerializable));
 							}
 							break;
 						case "SkipMethod":
-							if (rx != null) {
-								info.skipMethods.Add (new MethodTester (rx, type, attrib, typeattrib, inherits, isStatic));
-							} else {
-								info.skipMethods.Add (new MethodTester (name, type, attrib, typeattrib, inherits, isStatic));
+							if (rx != null)
+							{
+								info.skipMethods.Add(new MethodTester(rx, type, attrib, typeattrib, inherits, isStatic));
+							} else
+							{
+								info.skipMethods.Add(new MethodTester(name, type, attrib, typeattrib, inherits, isStatic));
 							}
 							break;
 						case "ForceMethod":
-							if (rx != null) {
-								info.forceMethods.Add (new MethodTester (rx, type, attrib, typeattrib, inherits, isStatic));
-							} else {
-								info.forceMethods.Add (new MethodTester (name, type, attrib, typeattrib, inherits, isStatic));
+							if (rx != null)
+							{
+								info.forceMethods.Add(new MethodTester(rx, type, attrib, typeattrib, inherits, isStatic));
+							} else
+							{
+								info.forceMethods.Add(new MethodTester(name, type, attrib, typeattrib, inherits, isStatic));
 							}
 							break;
 						case "SkipStringHiding":
-							if (rx != null) {
-								info.skipStringHiding.Add (new MethodTester (rx, type, attrib, typeattrib));
-							} else {
-								info.skipStringHiding.Add (new MethodTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.skipStringHiding.Add(new MethodTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.skipStringHiding.Add(new MethodTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "ForceStringHiding":
-							if (rx != null) {
-								info.forceStringHiding.Add (new MethodTester (rx, type, attrib, typeattrib));
-							} else {
-								info.forceStringHiding.Add (new MethodTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.forceStringHiding.Add(new MethodTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.forceStringHiding.Add(new MethodTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "SkipField":
-							string decorator = Helper.GetAttribute (reader, "decorator", vars);
+							string decorator = Helper.GetAttribute(reader, "decorator", vars);
 
-							if (rx != null) {
-								info.skipFields.Add (new FieldTester (rx, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
-							} else {
-								info.skipFields.Add (new FieldTester (name, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
+							if (rx != null)
+							{
+								info.skipFields.Add(new FieldTester(rx, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
+							} else
+							{
+								info.skipFields.Add(new FieldTester(name, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
 							}
 							break;
 						case "ForceField":
-							string decorator1 = Helper.GetAttribute (reader, "decorator", vars);
+							string decorator1 = Helper.GetAttribute(reader, "decorator", vars);
 
-							if (rx != null) {
-								info.forceFields.Add (new FieldTester (rx, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
-							} else {
-								info.forceFields.Add (new FieldTester (name, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
+							if (rx != null)
+							{
+								info.forceFields.Add(new FieldTester(rx, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
+							} else
+							{
+								info.forceFields.Add(new FieldTester(name, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
 							}
 							break;
 						case "SkipProperty":
-							if (rx != null) {
-								info.skipProperties.Add (new PropertyTester (rx, type, attrib, typeattrib));
-							} else {
-								info.skipProperties.Add (new PropertyTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.skipProperties.Add(new PropertyTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.skipProperties.Add(new PropertyTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "ForceProperty":
-							if (rx != null) {
-								info.forceProperties.Add (new PropertyTester (rx, type, attrib, typeattrib));
-							} else {
-								info.forceProperties.Add (new PropertyTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.forceProperties.Add(new PropertyTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.forceProperties.Add(new PropertyTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "SkipEvent":
-							if (rx != null) {
-								info.skipEvents.Add (new EventTester (rx, type, attrib, typeattrib));
-							} else {
-								info.skipEvents.Add (new EventTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.skipEvents.Add(new EventTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.skipEvents.Add(new EventTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "ForceEvent":
-							if (rx != null) {
-								info.forceEvents.Add (new EventTester (rx, type, attrib, typeattrib));
-							} else {
-								info.forceEvents.Add (new EventTester (name, type, attrib, typeattrib));
+							if (rx != null)
+							{
+								info.forceEvents.Add(new EventTester(rx, type, attrib, typeattrib));
+							} else
+							{
+								info.forceEvents.Add(new EventTester(name, type, attrib, typeattrib));
 							}
 							break;
 						case "SkipEnums":
-							var skipEnumsValue = Helper.GetAttribute (reader, "value");
-							info.skipEnums = skipEnumsValue.Length > 0 && XmlConvert.ToBoolean (skipEnumsValue);
+							var skipEnumsValue = Helper.GetAttribute(reader, "value");
+							info.skipEnums = skipEnumsValue.Length > 0 && XmlConvert.ToBoolean(skipEnumsValue);
 							break;
-						}                    
-					} else if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "Module") {
-						// hit end of module element...stop reading
-						break;
 					}
+				} else if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "Module")
+				{
+					// hit end of module element...stop reading
+					break;
 				}
 			}
-
-			return info;
 		}
 
 		/// <summary>
@@ -621,7 +667,7 @@ namespace Obfuscar
 
 		private bool ShouldSkip (TypeKey type, TypeAffectFlags flag, InheritMap map)
 		{
-			if (ShouldSkip (type.Namespace, map)) {				
+			if (ShouldSkip (type.Namespace, map)) {
 				return true;
 			}
 

--- a/Obfuscar/AssemblyInfo.cs
+++ b/Obfuscar/AssemblyInfo.cs
@@ -152,7 +152,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipNamespaces.Add(new NamespaceTester(rx));
-							} else
+							}
+							else
 							{
 								info.skipNamespaces.Add(new NamespaceTester(name));
 							}
@@ -161,7 +162,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceNamespaces.Add(new NamespaceTester(rx));
-							} else
+							}
+							else
 							{
 								info.forceNamespaces.Add(new NamespaceTester(name));
 							}
@@ -192,7 +194,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipTypes.Add(new TypeTester(rx, skipFlags, attrib, inherits, isStatic, isSerializable));
-							} else
+							}
+							else
 							{
 								info.skipTypes.Add(new TypeTester(name, skipFlags, attrib, inherits, isStatic, isSerializable));
 							}
@@ -223,7 +226,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceTypes.Add(new TypeTester(rx, forceFlags, attrib, inherits, isStatic, isSerializable));
-							} else
+							}
+							else
 							{
 								info.forceTypes.Add(new TypeTester(name, forceFlags, attrib, inherits, isStatic, isSerializable));
 							}
@@ -232,7 +236,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipMethods.Add(new MethodTester(rx, type, attrib, typeattrib, inherits, isStatic));
-							} else
+							}
+							else
 							{
 								info.skipMethods.Add(new MethodTester(name, type, attrib, typeattrib, inherits, isStatic));
 							}
@@ -241,7 +246,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceMethods.Add(new MethodTester(rx, type, attrib, typeattrib, inherits, isStatic));
-							} else
+							}
+							else
 							{
 								info.forceMethods.Add(new MethodTester(name, type, attrib, typeattrib, inherits, isStatic));
 							}
@@ -250,7 +256,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipStringHiding.Add(new MethodTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.skipStringHiding.Add(new MethodTester(name, type, attrib, typeattrib));
 							}
@@ -259,7 +266,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceStringHiding.Add(new MethodTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.forceStringHiding.Add(new MethodTester(name, type, attrib, typeattrib));
 							}
@@ -270,7 +278,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipFields.Add(new FieldTester(rx, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
-							} else
+							}
+							else
 							{
 								info.skipFields.Add(new FieldTester(name, type, attrib, typeattrib, inherits, decorator, isStatic, isSerializable));
 							}
@@ -281,7 +290,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceFields.Add(new FieldTester(rx, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
-							} else
+							}
+							else
 							{
 								info.forceFields.Add(new FieldTester(name, type, attrib, typeattrib, inherits, decorator1, isStatic, isSerializable));
 							}
@@ -290,7 +300,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipProperties.Add(new PropertyTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.skipProperties.Add(new PropertyTester(name, type, attrib, typeattrib));
 							}
@@ -299,7 +310,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceProperties.Add(new PropertyTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.forceProperties.Add(new PropertyTester(name, type, attrib, typeattrib));
 							}
@@ -308,7 +320,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.skipEvents.Add(new EventTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.skipEvents.Add(new EventTester(name, type, attrib, typeattrib));
 							}
@@ -317,7 +330,8 @@ namespace Obfuscar
 							if (rx != null)
 							{
 								info.forceEvents.Add(new EventTester(rx, type, attrib, typeattrib));
-							} else
+							}
+							else
 							{
 								info.forceEvents.Add(new EventTester(name, type, attrib, typeattrib));
 							}
@@ -327,7 +341,8 @@ namespace Obfuscar
 							info.skipEnums = skipEnumsValue.Length > 0 && XmlConvert.ToBoolean(skipEnumsValue);
 							break;
 					}
-				} else if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "Module")
+				}
+				else if (reader.NodeType == XmlNodeType.EndElement && reader.Name == "Module")
 				{
 					// hit end of module element...stop reading
 					break;

--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -146,7 +146,7 @@ namespace Obfuscar
 			}
 		}
 
-		private static XmlReaderSettings GetReaderSettings ()
+		internal static XmlReaderSettings GetReaderSettings ()
 		{
 			var settings = new XmlReaderSettings {
 				IgnoreProcessingInstructions = true,

--- a/Obfuscar/Project.cs
+++ b/Obfuscar/Project.cs
@@ -25,6 +25,7 @@ using Mono.Cecil;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
@@ -188,7 +189,8 @@ namespace Obfuscar
 			}
 		}
 
-		internal static void ReadIncludeTag(XmlReader parentReader, Project project, Action<XmlReader, Project> readAction) {
+		internal static void ReadIncludeTag(XmlReader parentReader, Project project, Action<XmlReader, Project> readAction)
+		{
 			if (parentReader == null)
 				throw new ArgumentNullException("parentReader");
 
@@ -197,14 +199,18 @@ namespace Obfuscar
 
 			string path = Environment.ExpandEnvironmentVariables(project.vars.Replace(Helper.GetAttribute(parentReader, "path")));
 			XmlReaderSettings includeReaderSettings = Obfuscator.GetReaderSettings();
-			using (XmlReader includeReader = XmlReader.Create(File.OpenRead(path), includeReaderSettings)) {
+			using (XmlReader includeReader = XmlReader.Create(File.OpenRead(path), includeReaderSettings))
+			{
 				// Start reading
 				includeReader.Read();
 
 				// Skip declaration, if present
-				if (includeReader.NodeType == XmlNodeType.XmlDeclaration) {
+				if (includeReader.NodeType == XmlNodeType.XmlDeclaration)
+				{
 					includeReader.Read();
 				}
+
+				Debug.Assert(includeReader.NodeType == XmlNodeType.Element && includeReader.Name == "Include");
 
 				readAction(includeReader, project);
 			}

--- a/Tests/IncludeTests.cs
+++ b/Tests/IncludeTests.cs
@@ -1,0 +1,53 @@
+#region Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+/// <copyright>
+/// Copyright (c) 2007 Ryan Williams <drcforbin@gmail.com>
+///
+/// Permission is hereby granted, free of charge, to any person obtaining a copy
+/// of this software and associated documentation files (the "Software"), to deal
+/// in the Software without restriction, including without limitation the rights
+/// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+/// copies of the Software, and to permit persons to whom the Software is
+/// furnished to do so, subject to the following conditions:
+///
+/// The above copyright notice and this permission notice shall be included in
+/// all copies or substantial portions of the Software.
+///
+/// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+/// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+/// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+/// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+/// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+/// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+/// THE SOFTWARE.
+/// </copyright>
+#endregion
+
+using System;
+using System.IO;
+using Obfuscar;
+using Xunit;
+
+namespace ObfuscarTests
+{
+	public class IncludeTests
+	{
+		[Fact]
+		public void TestInclude ()
+		{
+			string xml = String.Format (
+				@"<?xml version='1.0'?>" +
+				@"<Obfuscator>" +
+				@"<Var name='InPath' value='{0}' />" +
+				@"<Var name='OutPath' value='{1}' />" +
+				@"<Var name='KeepPublicApi' value='false' />" +
+				@"<Var name='HidePrivateApi' value='true' />" +
+				@"<Include path='$(InPath){2}TestInclude.xml' />" +
+				@"<Module file='$(InPath){2}AssemblyWithCustomAttr.dll'>" +
+				@"<Include path='$(InPath){2}TestIncludeModule.xml' />" +
+				@"</Module>" +
+				@"</Obfuscator>", TestHelper.InputPath, TestHelper.OutputPath, Path.DirectorySeparatorChar);
+
+			Obfuscator obfuscator = Obfuscator.CreateFromXml( xml );
+		}
+	}
+}

--- a/Tests/Input/TestInclude.xml
+++ b/Tests/Input/TestInclude.xml
@@ -1,0 +1,1 @@
+<?xml version='1.0'?><Include><Var name='TestIncludeVar' value='Foo' /></Include>

--- a/Tests/Input/TestIncludeModule.xml
+++ b/Tests/Input/TestIncludeModule.xml
@@ -1,0 +1,1 @@
+<?xml version='1.0'?><Include><SkipMethod type='SkipVirtualMethodTest.Interface1' name='Method1' /></Include>

--- a/Tests/ObfuscarTests.csproj
+++ b/Tests/ObfuscarTests.csproj
@@ -72,6 +72,7 @@
     <Compile Include="HideStringsTests.cs" />
     <Compile Include="PortableTests.cs" />
     <Compile Include="ResourcesTests.cs" />
+    <Compile Include="IncludeTests.cs" />
     <Compile Include="SigningTests.cs" />
     <Compile Include="SkipNestedTypeTests.cs" />
     <Compile Include="SkipVirtualMethodTest.cs" />


### PR DESCRIPTION
Solves issue #10.
Adds `<include>` tag that "inserts" the contents of the file into configuration. This allows to separate repeating stuff into files for reuse.

Usage example:
```
<?xml version="1.0" encoding="UTF-8"?>
<Obfuscator>
   <Var name="InPath" value="..\..\Input" />
   <Var name="OutPath" value="..\..\Output" />
   <Var name="KeepPublicApi" value="false" />
   <Var name="HidePrivateApi" value="true" />
   <Include path="$(InPath)\TestInclude.xml" />
   <Module file="$(InPath)\AssemblyWithCustomAttr.dll">
      <Include path="$(InPath)\TestIncludeModule.xml" />
   </Module>
</Obfuscator>
```
TestInclude.xml:
```
<?xml version='1.0'?>
<Include>
<Var name='TestIncludeVar' value='Foo' />
</Include>
```
TestIncludeModule.xml:
```
<?xml version='1.0'?>
<Include>
<SkipMethod type='SkipVirtualMethodTest.Interface1' name='Method1' />
</Include>
```