### PR TITLE
Fixed crash on Mono runtime when using string hiding

### DIFF
--- a/Obfuscar/Obfuscator.cs
+++ b/Obfuscar/Obfuscator.cs
@@ -1252,7 +1252,7 @@ namespace Obfuscar
 				Method3 = library.MainModule.Import (runtimeHelpers.Methods.FirstOrDefault (method => method.Name == "InitializeArray"));
 
 				// New static class with a method for each unique string we substitute.
-				NewType = new TypeDefinition ("<PrivateImplementationDetails>{" + Guid.NewGuid ().ToString ().ToUpper () + "}", null, TypeAttributes.BeforeFieldInit | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit, systemObjectTypeReference);
+				NewType = new TypeDefinition ("<PrivateImplementationDetails>{" + Guid.NewGuid ().ToString ().ToUpper () + "}", Guid.NewGuid ().ToString ().ToUpper (), TypeAttributes.BeforeFieldInit | TypeAttributes.AutoClass | TypeAttributes.AnsiClass | TypeAttributes.BeforeFieldInit, systemObjectTypeReference);
 
 				// Add struct for constant byte array data
 				StructType = new TypeDefinition ("\0", "", TypeAttributes.ExplicitLayout | TypeAttributes.AnsiClass | TypeAttributes.Sealed | TypeAttributes.NestedPrivate, systemValueTypeTypeReference);


### PR DESCRIPTION
The type used for string hiding uses `null` for a name. Mono runtime really doesn't likes that, resulting in spectacular crash when loading the assembly. This fixes the issue by using a random name instead.